### PR TITLE
A: fau.de, fau.eu

### DIFF
--- a/easylist_cookie/easylist_cookie_international_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_international_specific_hide.txt
@@ -424,6 +424,7 @@ prospekt.aldi-sued.de##div[id^="ppms_cm_consent_popup_"]
 smart-mail.de##div[style*="position: fixed; padding-top:"]
 pcwarehouse.be##div[style*="width: 100%; background-color: #474747; padding-top: 0px; margin-top: 0px;"]
 oebv.net##form > div
+fau.de,fau.eu##.show-cookie-box
 !
 ! ---------- French ----------
 !


### PR DESCRIPTION
Completely block the cookie consent banner, which was currently partly blocked, resulting in a broken page. Example URLs:
https://www.fau.de/
https://www.economics.phil.fau.eu/
https://www.rrze.fau.de/